### PR TITLE
improve description of Setter Injection in Injections.md

### DIFF
--- a/manuals/1.0/en/Injections.md
+++ b/manuals/1.0/en/Injections.md
@@ -25,7 +25,7 @@ public function __construct(DbInterface $db)
 
 ## Setter Injection
 
-Ray.Di can inject dependencies through methods that have the `#[Inject]` attribute. Dependencies take the form of parameters, which the injector resolves before invoking the method. Injected methods may have any number of parameters, and the method name does not impact injection.
+Ray.Di can inject by methods that have the `#[Inject]` attribute. Dependencies take the form of parameters, which the injector resolves before invoking the method. Injected methods may have any number of parameters, and the method name does not impact injection.
 
 ```php
 use Ray\Di\Di\Inject;

--- a/manuals/1.0/en/Injections.md
+++ b/manuals/1.0/en/Injections.md
@@ -25,7 +25,7 @@ public function __construct(DbInterface $db)
 
 ## Setter Injection
 
-Ray.Di can inject methods that have the `#[Inject]` attribute. Dependencies take the form of parameters, which the injector resolves before invoking the method. Injected methods may have any number of parameters, and the method name does not impact injection.
+Ray.Di can inject dependencies through methods that have the `#[Inject]` attribute. Dependencies take the form of parameters, which the injector resolves before invoking the method. Injected methods may have any number of parameters, and the method name does not impact injection.
 
 ```php
 use Ray\Di\Di\Inject;


### PR DESCRIPTION
To clarify the meaning and improve DeepL translation :grin: 

## before

```
Ray.Diは `#[Inject]` 属性を持つメソッドをインジェクトすることができます。依存関係はパラメータの形式をとり、インジェクタはメソッドを呼び出す前にそれを解決します。注入されるメソッドは任意の数のパラメータを持つことができ、メソッド名は注入に影響を与えません。
```

## after

```
Ray.Diは `#[Inject]` 属性を持つメソッドを通して依存関係を注入することができます。依存関係はパラメータの形式をとり、インジェクタはメソッドを呼び出す前にそれを解決します。注入されるメソッドは任意の数のパラメータを持つことができ、メソッド名は注入に影響を与えません。
```