### PR TITLE
Fix php syntax errors in docs: "public class" -> "class"

### DIFF
--- a/manuals/1.0/en/Bindings.md
+++ b/manuals/1.0/en/Bindings.md
@@ -22,8 +22,8 @@ class TweetModule extends AbstractModule
     {
         $this->bind(TweetClient::class);
         $this->bind(TweeterInterface::class)->to(SmsTweeter::class)->in(Scope::SINGLETON);
-        $this->bind(UrlShortenerInterface)->toProvider(TinyUrlShortener::class)
-        $this->bind('')->annotatedWith(Username::class)->toInstance("koriym")
+        $this->bind(UrlShortenerInterface)->toProvider(TinyUrlShortener::class);
+        $this->bind('')->annotatedWith(Username::class)->toInstance("koriym");
     }
 }
 ```

--- a/manuals/1.0/en/ConstructorBindings.md
+++ b/manuals/1.0/en/ConstructorBindings.md
@@ -60,7 +60,7 @@ Specify the method name ($methodName) and qualifier ($named) of the setter injec
 (new InjectionPoints)
 	->addMethod($methodName1)
 	->addMethod($methodName2, $named)
-        ->addOptionalMethod($methodName, $named)
+        ->addOptionalMethod($methodName, $named);
 ```
 
 **postCosntruct**

--- a/manuals/1.0/en/InjectingProviders.md
+++ b/manuals/1.0/en/InjectingProviders.md
@@ -22,7 +22,7 @@ interface Provider
 Provider types are marked with a qualifier to distinguish `Provider<TransactionLog>` from `Provider<CreditCardProcessor>`. Wherever you inject a value, you can inject a provider for that value.
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public __construct(
         #[QureditCardProcessor] private Provider $processorProvider,
@@ -121,7 +121,7 @@ Instead, you should use a Provider. Since Providers produce values on-demand,
 they enable you to mix scopes safely:
 
 ```php
-public class ConsoleTransactionLog implements TransactionLogInterface
+class ConsoleTransactionLog implements TransactionLogInterface
 {
     public function __construct(
         #[User] private readonly Provider $userProvider

--- a/manuals/1.0/en/Injections.md
+++ b/manuals/1.0/en/Injections.md
@@ -88,7 +88,7 @@ causes Ray.Di to silently ignore them when the dependencies aren't available. To
 use optional injection, apply the `#[Inject(optional: true)`attribute:
 
 ```php
-public class PayPalCreditCardProcessor implements CreditCardProcessorInterface
+class PayPalCreditCardProcessor implements CreditCardProcessorInterface
 {
     private const SANDBOX_API_KEY = "development-use-only";
     private string $apiKey = self::SANDBOX_API_KEY;

--- a/manuals/1.0/en/MentalModel.md
+++ b/manuals/1.0/en/MentalModel.md
@@ -187,7 +187,7 @@ do this:
 
 Conceptually, these APIs simply provide ways to manipulate the Ray.Di map. The
 manipulations they do are pretty straightforward. Here are some example
-translations, shown using Java 8 syntax for brevity and clarity:
+translations, shown using PHP syntax for brevity and clarity:
 
 | Ray.Di DSL syntax                   | Mental model                                                                       |
 | ---------------------------------- | ---------------------------------------------------------------------------------- |

--- a/manuals/1.0/en/Motivation.md
+++ b/manuals/1.0/en/Motivation.md
@@ -109,7 +109,7 @@ class RealBillingService implements BillingServiceInterface
                 : Receipt::forDeclinedCharge($result->getDeclineMessage());
         } catch (UnreachableException $e) {
             $transactionLog->logConnectException($e);
-            return Receipt::forSystemFailure($e.getMessage());
+            return Receipt::forSystemFailure($e->getMessage());
         }
     }
 }
@@ -122,7 +122,7 @@ class RealBillingServiceTest extends TestCase
 {
     private PizzaOrder $order;
     private CreditCard $creditCard;
-    private InMemoryTransactionLog $transactionLog
+    private InMemoryTransactionLog $transactionLog;
     private FakeCreditCardProcessor $processor;
     
     public function setUp(): void
@@ -258,7 +258,7 @@ $billingService = new RealBillingService($processor, $transactionLog);
 The dependency injection pattern leads to code that's modular and testable, and
 Ray.Di makes it easy to write. To use Ray.Di in our billing example, we first need
 to tell it how to map our interfaces to their implementations. This
-configuration is done in a Ray.Di module, which is any Java class that implements
+configuration is done in a Ray.Di module, which is any PHP class that implements
 the `Module` interface:
 
 ```php

--- a/manuals/1.0/en/Motivation.md
+++ b/manuals/1.0/en/Motivation.md
@@ -35,7 +35,7 @@ Here's what the code looks like when we just `new` up the credit card processor
 and transaction logger:
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function chargeOrder(PizzaOrder $order, CreditCard $creditCard): Receipt
     {
@@ -70,7 +70,7 @@ uses static methods to get and set mock implementations for interfaces. A
 factory is implemented with some boilerplate code:
 
 ```php
-public class CreditCardProcessorFactory
+class CreditCardProcessorFactory
 {
     private static CreditCardProcessor $instance;
     
@@ -93,7 +93,7 @@ public class CreditCardProcessorFactory
 In our client code, we just replace the `new` calls with factory lookups:
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function chargeOrder(PizzaOrder $order, CreditCard $creditCard): Receipt
     {
@@ -118,7 +118,7 @@ public class RealBillingService implements BillingServiceInterface
 The factory makes it possible to write a proper unit test:
 
 ```php
-public class RealBillingServiceTest extends TestCase 
+class RealBillingServiceTest extends TestCase 
 {
     private PizzaOrder $order;
     private CreditCard $creditCard;
@@ -178,7 +178,7 @@ the `RealBillingService` is not responsible for looking up the `TransactionLog`
 and `CreditCardProcessor`. Instead, they're passed in as constructor parameters:
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function __construct(
         private readonly CreditCardProcessor $processor,
@@ -207,7 +207,7 @@ We don't need any factories, and we can simplify the testcase by removing the
 `setUp` and `tearDown` boilerplate:
 
 ```php
-public class RealBillingServiceTest extends TestCase
+class RealBillingServiceTest extends TestCase
 {
     private PizzaOrder $order;
     private CreditCard $creditCard;
@@ -262,7 +262,7 @@ configuration is done in a Ray.Di module, which is any Java class that implement
 the `Module` interface:
 
 ```php
-public class BillingModule extends AbstractModule
+class BillingModule extends AbstractModule
 {
     protected function configure(): void
     {
@@ -276,7 +276,7 @@ public class BillingModule extends AbstractModule
 Ray.Di will inspect the  constructor, and lookup values for each parameter.
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function __construct(
         private readonly CreditCardProcessor $processor,

--- a/manuals/1.0/ja/Bindings.md
+++ b/manuals/1.0/ja/Bindings.md
@@ -22,8 +22,8 @@ class TweetModule extends AbstractModule
     {
         $this->bind(TweetClient::class);
         $this->bind(TweeterInterface::class)->to(SmsTweeter::class)->in(Scope::SINGLETON);
-        $this->bind(UrlShortenerInterface)->toProvider(TinyUrlShortener::class)
-        $this->bind('')->annotatedWith(Username::class)->toInstance("koriym")
+        $this->bind(UrlShortenerInterface)->toProvider(TinyUrlShortener::class);
+        $this->bind('')->annotatedWith(Username::class)->toInstance("koriym");
     }
 }
 ```

--- a/manuals/1.0/ja/ConstructorBindings.md
+++ b/manuals/1.0/ja/ConstructorBindings.md
@@ -60,7 +60,7 @@ Specify the method name ($methodName) and qualifier ($named) of the setter injec
 (new InjectionPoints)
 	->addMethod($methodName1)
 	->addMethod($methodName2, $named)
-        ->addOptionalMethod($methodName, $named)
+        ->addOptionalMethod($methodName, $named);
 ```
 
 **postCosntruct**

--- a/manuals/1.0/ja/InjectingProviders.md
+++ b/manuals/1.0/ja/InjectingProviders.md
@@ -22,7 +22,7 @@ interface Provider
 Provider types are marked with a qualifier to distinguish `Provider<TransactionLog>` from `Provider<CreditCardProcessor>`. Wherever you inject a value, you can inject a provider for that value.
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public __construct(
         #[QureditCardProcessor] private Provider $processorProvider,
@@ -121,7 +121,7 @@ Instead, you should use a Provider. Since Providers produce values on-demand,
 they enable you to mix scopes safely:
 
 ```php
-public class ConsoleTransactionLog implements TransactionLogInterface
+class ConsoleTransactionLog implements TransactionLogInterface
 {
     public function __construct(
         #[User] private readonly Provider $userProvider

--- a/manuals/1.0/ja/Injections.md
+++ b/manuals/1.0/ja/Injections.md
@@ -88,7 +88,7 @@ causes Ray.Di to silently ignore them when the dependencies aren't available. To
 use optional injection, apply the `#[Inject(optional: true)`attribute:
 
 ```php
-public class PayPalCreditCardProcessor implements CreditCardProcessorInterface
+class PayPalCreditCardProcessor implements CreditCardProcessorInterface
 {
     private const SANDBOX_API_KEY = "development-use-only";
     private string $apiKey = self::SANDBOX_API_KEY;

--- a/manuals/1.0/ja/Motivation.md
+++ b/manuals/1.0/ja/Motivation.md
@@ -97,7 +97,7 @@ class RealBillingService implements BillingServiceInterface
                 : Receipt::forDeclinedCharge($result->getDeclineMessage());
         } catch (UnreachableException $e) {
             $transactionLog->logConnectException($e);
-            return Receipt::forSystemFailure($e.getMessage());
+            return Receipt::forSystemFailure($e->getMessage());
         }
     }
 }
@@ -110,7 +110,7 @@ class RealBillingServiceTest extends TestCase
 {
     private PizzaOrder $order;
     private CreditCard $creditCard;
-    private InMemoryTransactionLog $transactionLog
+    private InMemoryTransactionLog $transactionLog;
     private FakeCreditCardProcessor $processor;
     
     public function setUp(): void

--- a/manuals/1.0/ja/Motivation.md
+++ b/manuals/1.0/ja/Motivation.md
@@ -28,7 +28,7 @@ interface BillingServiceInterface
 以下は、クレジットカードプロセッサーとトランザクションロガーを `new` したときのコードです。
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function chargeOrder(PizzaOrder $order, CreditCard $creditCard): Receipt
     {
@@ -58,7 +58,7 @@ public class RealBillingService implements BillingServiceInterface
 ファクトリークラスは、クライアントと実装クラスを切り離します。単純なファクトリーでは、静的メソッドを使用してインターフェースのモック実装を取得したり設定したりします。ファクトリーはいくつかの定型的なコードで実装されます。
 
 ```php
-public class CreditCardProcessorFactory
+class CreditCardProcessorFactory
 {
     private static CreditCardProcessor $instance;
     
@@ -81,7 +81,7 @@ public class CreditCardProcessorFactory
 クライアントコードでは、`new`の呼び出しをファクトリーの呼び出しに置き換えるだけです。
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function chargeOrder(PizzaOrder $order, CreditCard $creditCard): Receipt
     {
@@ -106,7 +106,7 @@ public class RealBillingService implements BillingServiceInterface
 ファクトリーを利用することで、適切なユニットテストを書くことが可能になります。
 
 ```php
-public class RealBillingServiceTest extends TestCase 
+class RealBillingServiceTest extends TestCase 
 {
     private PizzaOrder $order;
     private CreditCard $creditCard;
@@ -153,7 +153,7 @@ public class RealBillingServiceTest extends TestCase
 ファクトリーと同様、依存性の注入も単なるデザインパターンに過ぎません。核となる原則は、依存関係の解決から振る舞いを **分離する** ことです。この例では、 `RealBillingService` は `TransactionLog` と `CreditCardProcessor` を探す責任はありません。代わりに、コンストラクタのパラメータとして渡されます。
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function __construct(
         private readonly CreditCardProcessor $processor,
@@ -181,7 +181,7 @@ public class RealBillingService implements BillingServiceInterface
 ファクトリーは必要ありませんし、`setUp` と `tearDown` の定型的なコードを削除することで、テストケースを簡素化することができます。
 
 ```php
-public class RealBillingServiceTest extends TestCase
+class RealBillingServiceTest extends TestCase
 {
     private PizzaOrder $order;
     private CreditCard $creditCard;
@@ -227,7 +227,7 @@ $billingService = new RealBillingService($processor, $transactionLog);
 依存性の注入パターンは、モジュール化されたテスト可能なコードを導き、Ray.Diで簡単にコードを書けるようにします。課金の例でRay.Diを使うには、まずインターフェイスとその実装をどのように対応付けるかを指示する必要があります。設定は`Module`インターフェースを実装したRay.Diモジュールクラスで行われます。
 
 ```php
-public class BillingModule extends AbstractModule
+class BillingModule extends AbstractModule
 {
     protected function configure(): void
     {
@@ -241,7 +241,7 @@ public class BillingModule extends AbstractModule
 Ray.Diはコンストラクタを検査し、各引数の値を検索します。
 
 ```php
-public class RealBillingService implements BillingServiceInterface
+class RealBillingService implements BillingServiceInterface
 {
     public function __construct(
         private readonly CreditCardProcessor $processor,


### PR DESCRIPTION
refs #4 

問題：
PHPへと置換済みのコード例のなかに、classに対するアクセス修飾子が使用されている箇所があります
たぶん、Guiceドキュメントに書かれていたJavaコードの名残かなと思います

ex: Motivation／モチベーション中のコード
```php
public class RealBillingService implements BillingServiceInterface
```

対応：
- 現時点で明確にphp化されていそうな箇所については、publicを外しておきました
- まだjavaかもしれない箇所（マークダウン上のコードブロックでの言語指定がまだ``java``になっている箇所）はいったん対応から外しました
  - やる方向でも全然大丈夫です。その場合、レビューコメントくだされば幸いです
  - ちなみに、追加でPHP化対応しても特段問題なさそうならやってしまうのもアリかな、と思っています