### PR TITLE
Translated the section "Constructor Bindings" from En to Ja

### DIFF
--- a/manuals/1.0/ja/ConstructorBindings.md
+++ b/manuals/1.0/ja/ConstructorBindings.md
@@ -4,12 +4,14 @@ title: Constructor Bindings
 category: Manual
 permalink: /manuals/1.0/ja/constructor_bindings.html
 ---
-## Constructor Bindings
 
-When `#[Inject]` attribute cannot be applied to the target constructor or setter method because it is a third party class, Or you simply don't like to use annotations. `Constructor Binding` provide the solution to this problem. By calling your target constructor explicitly, you don't need reflection and its associated pitfalls. But there are limitations of that approach: manually constructed instances do not participate in AOP.
+## コンストラクタ束縛
 
-To address this, Ray.Di has `toConstructor` bindings.
+時には対象のコンストラクタやセッターメソッドがサードパーティ製であるため`#[Inject]`アトリビュートが適用できない場合や、あるいは単にアトリビュートを使いたくない場合があります。
 
+コンストラクタ束縛はこの問題を解決します。つまり、対象となるコンストラクタをユーザー側で明示的に呼び出すことで、リフレクションやそれに関する面倒を考える必要がなくなります。
+
+これに対処するため、Ray.Diには`toConstructor`束縛があります。
 
 ```php
 $this->bind($interfaceName)
@@ -20,73 +22,79 @@ $this->bind($interfaceName)
         $postConstruct
     );
 
-(new InjectionPoints)                       // InjectionPoints　$setter_injection
+(new InjectionPoints) // InjectionPoints $setter_injection
     ->addMethod('setGuzzle', 'token')
-    ->addOptionalMethod('setOptionalToken', 'initialize');           // string $postCostruct
+    ->addOptionalMethod('setOptionalToken', 'initialize'); // string $postCostruct
 $this->bind()->annotated('user_id')->toInstance($_ENV['user_id']);
 $this->bind()->annotated('user_password')->toInstance($_ENV['user_password']);
 
 ```
 
-
 ### Parameter
 
 **class_name**
 
-Class name
+クラス名
 
 **name**
 
-Parameter name binding.
+パラメーター名束縛
 
-If you want to add an identifier to the argument, specify an array with the variable name as the key and the value as the name of the identifier.
+引数に識別子を追加する場合は、キーを変数名、値を識別子とする配列を指定します。
 
-
-```
+```php
 [
 	[$param_name1 => $binding_name1],
 	...
 ]
 ```
-The following string formats are also supported
 
+以下のストリングフォーマットもサポートされています。
 `'param_name1=binding_name1&...'`
 
 **setter_injection**
 
-Specify the method name ($methodName) and qualifier ($named) of the setter injector in the `InjectionPoints` object.
+`InjectionPoints`オブジェクトでセッターインジェクションのメソッド名($methodName)と識別子($named)を指定します。
 
 ```php
 (new InjectionPoints)
 	->addMethod($methodName1)
 	->addMethod($methodName2, $named)
-        ->addOptionalMethod($methodName, $named);
+  ->addOptionalMethod($methodName, $named);
 ```
 
 **postCosntruct**
 
-Ray.Di will invoke that constructor and setter method to satisfy the binding and invoke in `$postCosntruct` method after all dependencies are injected.
+コンストラクタとセッターメソッドが呼び出され、すべての依存関係が注入された後に`$postCosntruct`メソッドが呼び出されます
 
 ### PDO Example
 
-Here is the example for the native [PDO](http://php.net/manual/ja/pdo.construct.php) class.
+[PDO](http://php.net/manual/ja/pdo.construct.php)クラスの束縛の例です。
 
 ```php
-public PDO::__construct ( string $dsn [, string $username [, string $password [, array $options ]]] )
+public PDO::__construct(
+    string $dsn,
+    ?string $username = null,
+    ?string $password = null,
+    ?array $options = null
+)
 ```
 
 ```php
 $this->bind(\PDO::class)->toConstructor(
-  \PDO::class,
-  [
-    'dsn' => 'pdo_dsn',
-    'username' => 'pdo_username',
-    'password' => 'pdo_password'
-  ]
+    \PDO::class,
+    [
+        'dsn' => 'pdo_dsn',
+        'username' => 'pdo_username',
+        'password' => 'pdo_password'
+    ]
 )->in(Scope::SINGLETON);
+
 $this->bind()->annotatedWith('pdo_dsn')->toInstance($dsn);
 $this->bind()->annotatedWith('pdo_username')->toInstance(getenv('db_user'));
 $this->bind()->annotatedWith('pdo_password')->toInstance(getenv('db_password'));
 ```
 
-Since no argument of PDO has a type, it binds with the `Name Binding` of the second argument of the `toConstructor()` method.
+PDOのコンストラクタ引数は`$dsn`, `$username`などstringの値を受け取り、その束縛を区別するために識別子が必要です。しかしPDOはPHP自体のビルトインクラスなのでアトリビュートを加えることができません。
+
+`toConstructor()`の第2引数の`$name`で識別子を指定します。


### PR DESCRIPTION
## Context

- refs: #4 

## What I did

- Constructor Bindingsの翻訳をしました

## Policy

- 翻訳段階での改変箇所については、セルフレビューコメントで指示します
  - かえってわかりにくい場合、直訳に戻そうと思います！
- Constructor Bindingsという例外的な仕様を設けた意図やユースケースが伝わるように努めました。主に下記です
  - 3rd Party製のライブラリの依存関係についてもRay.Diの世界に組み込みたい場合を考慮して作られた仕様である旨が伝わること
  - Native PDOでの実装例がDoc本体の再説明として機能すること
- [https://github.com/ray-di/Ray.Di/blob/2.13.3/README.ja.md#コンストラクタ束縛](https://github.com/ray-di/Ray.Di/blob/2.13.3/README.ja.md#%E3%82%B3%E3%83%B3%E3%82%B9%E3%83%88%E3%83%A9%E3%82%AF%E3%82%BF%E6%9D%9F%E7%B8%9B)を参照しました
  - README -> 英文Docへの翻訳を行った際に改変された箇所については英文側を正として捉えました
    - 特にProvider束縛を使った方法の箇所はあえて触れていないのかなと思いましたので、今回の日本語verでもオミットしています

## Calibration Rules

- 「セッタ」「セッター」「コンストラクタ」「コンストラクター」などの表記について
  - 単独語の場合は長音記号を略しました
  - 複合語の場合は長音記号を含めました ex: セッターメソッド、セッターインジェクション
