### PR TITLE
Translate Linked Bindings from English to Japanese

### DIFF
--- a/manuals/1.0/en/LinkedBindings.md
+++ b/manuals/1.0/en/LinkedBindings.md
@@ -8,8 +8,6 @@ permalink: /manuals/1.0/en/linked_bindings.html
 
 Linked bindings map a type to its implementation. This example maps the interface TransactionLogInterface to the implementation DatabaseTransactionLog:
 
-For example, the following code links the concrete DatabaseTransactionLog class to a subclass:
-
 ```php
 $this->bind(TransactionLogInterface::class)->to(DatabaseTransactionLog::class);
 ```

--- a/manuals/1.0/ja/LinkedBindings.md
+++ b/manuals/1.0/ja/LinkedBindings.md
@@ -1,14 +1,12 @@
 ---
 layout: docs-ja
-title: Linked Bindings
+title: リンク束縛
 category: Manual
 permalink: /manuals/1.0/ja/linked_bindings.html
 ---
-## Linked Bindings
+## リンク束縛
 
-Linked bindings map a type to its implementation. This example maps the interface TransactionLogInterface to the implementation DatabaseTransactionLog:
-
-For example, the following code links the concrete DatabaseTransactionLog class to a subclass:
+リンク束縛は、型とその実装をマッピングします。この例では、インターフェース TransactionLogInterface を実装 DatabaseTransactionLog にひもづけています。
 
 ```php
 $this->bind(TransactionLogInterface::class)->to(DatabaseTransactionLog::class);


### PR DESCRIPTION
I translated Linked Bindings.md from English to Japanese.

I checked the [juice documentation](https://github.com/google/guice/wiki/LinkedBindings), and it seems that the removal and simplification of the Java code made some of it redundant. So I removed the third sentence.

Related https://github.com/ray-di/ray-di.github.io/issues/4