### PR TITLE
Corrected the type mismatch of the return value of the function in docs

### DIFF
--- a/manuals/1.0/en/20.GettingStarted.md
+++ b/manuals/1.0/en/20.GettingStarted.md
@@ -104,7 +104,7 @@ class CountProvider implements ProviderInterface
 
 class MessageProvider implements ProviderInterface
 {
-    public function get(): int
+    public function get(): string
     {
         return 'hello world';
     }

--- a/manuals/1.0/ja/20.GettingStarted.md
+++ b/manuals/1.0/ja/20.GettingStarted.md
@@ -101,7 +101,7 @@ class CountProvider implements ProviderInterface
 
 class MessageProvider implements ProviderInterface
 {
-    public function get(): int
+    public function get(): string
     {
         return 'hello world';
     }


### PR DESCRIPTION
Hi, I found a minor error in the document and sent a PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `get` method in the `MessageProvider` class now returns a string instead of an integer, enhancing its output to provide a more meaningful textual response ('hello world').

- **Documentation**
	- Updated the English and Japanese Getting Started manuals to reflect the changes in the `get` method's return type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->