### PR TITLE
Add LLMs nav link and anchor-js

### DIFF
--- a/_includes/manuals/1.0/footer.html
+++ b/_includes/manuals/1.0/footer.html
@@ -14,6 +14,10 @@
 <script src="//code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="//stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+{% if page.category == 'Manual' %}
+<script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
+<script>anchors.add('h2, h3, h4');</script>
+{% endif %}
 <script src="/js/generate-table-of-contents/index.min.js"></script>
 <script>
     var toc = generateTableOfContents(document.getElementById('article'));

--- a/_includes/manuals/1.0/header.html
+++ b/_includes/manuals/1.0/header.html
@@ -28,6 +28,9 @@
                 <li class="nav-item">
                     <a class="intl nav-link {% if page.category == 'Manual' %}active{% endif %}" href="/manuals/1.0/en/index.html">Manual</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/llms-full.txt">LLMs</a>
+                </li>
             </ul>
         </div>
         {% if page.category == 'Manual' %}


### PR DESCRIPTION
## Summary

- Add LLMs link to navigation header for AI-friendly documentation access
- Add anchor-js to show hover links on h2-h4 headings (consistent with bearsunday.github.io)

## Summary by Sourcery

Add an LLMs navigation link to the manuals header and enable anchored heading links in manual pages.

New Features:
- Expose an LLMs text resource via a new navigation link in the manuals header.
- Add automatic anchor links to h2–h4 headings on manual pages using anchor-js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "LLMs" navigation link to header menu
  * Enabled automatic anchor links on manual pages for improved navigation within content sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->