### PR TITLE
Improve locale-aware manual links

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,12 @@ category: Index
             const locales = (navigatorLanguages && navigatorLanguages.length)
                 ? navigatorLanguages
                 : [window.navigator.language ?? ''];
-            const prefersJapanese = locales.some((locale) => locale.toLowerCase().startsWith('ja'));
+            const preferredSupportedLocale = locales.find((locale) => {
+                const lowerLocale = locale.toLowerCase();
+
+                return lowerLocale.startsWith('ja') || lowerLocale.startsWith('en');
+            }) ?? '';
+            const prefersJapanese = preferredSupportedLocale.startsWith('ja');
 
             if (!prefersJapanese) {
                 return;

--- a/index.html
+++ b/index.html
@@ -14,12 +14,22 @@ category: Index
         Overview &raquo;
     </a>
     <script>
-        window.addEventListener('DOMContentLoaded', (event) => {
+        window.addEventListener('DOMContentLoaded', () => {
+            const navigatorLanguages = window.navigator.languages;
+            const locales = (navigatorLanguages && navigatorLanguages.length)
+                ? navigatorLanguages
+                : [window.navigator.language ?? ''];
+            const prefersJapanese = locales.some((locale) => locale.toLowerCase().startsWith('ja'));
+
+            if (!prefersJapanese) {
+                return;
+            }
+
             const links = document.getElementsByClassName('intl');
-            const locale = window.navigator.language;
-            if (locale.startsWith('ja')) {
-                for(let i = 0; i < links.length; i++) {
-                    links[i].setAttribute('href', links[i].getAttribute('href').replace('/en/', '/ja/'));
+            for (const link of links) {
+                const href = link.getAttribute('href');
+                if (href && href.includes('/en/')) {
+                    link.setAttribute('href', href.replace('/en/', '/ja/'));
                 }
             }
         });


### PR DESCRIPTION
## What changed

- updated the landing-page locale helper to use navigator.languages with navigator.language fallback
- kept the manual entry link English by default and switched it to Japanese only for Japanese-preferring browsers

## Why

- this aligns Ray.Di with the newer locale selection behavior used across the manual sites
- it improves browser-language matching without changing permalink structure

## Notes

- this PR is isolated on top of master and contains only the locale-link change
- local Jekyll build was not completed here because the required gems were not available in the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Japanese language detection by evaluating the full ordered list of browser language preferences with a fallback to the primary language, ensuring correct locale selection.
  * Made internationalized link updates more precise: links are now evaluated individually and only rewritten when they contain the expected path segment, avoiding unnecessary or incorrect rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->